### PR TITLE
fix YulDeployer

### DIFF
--- a/test/lib/YulDeployer.sol
+++ b/test/lib/YulDeployer.sol
@@ -9,7 +9,10 @@ contract YulDeployer is Test {
     ///@param fileName - The file name of the Yul contract. For example, the file name for "Example.yul" is "Example"
     ///@return deployedAddress - The address that the contract was deployed to
     function deployContract(string memory fileName) public returns (address) {
-        string memory bashCommand = string.concat('cast abi-encode "f(bytes)" $(solc --strict-assembly yul/', string.concat(fileName, ".yul --bin | grep '^[0-9a-fA-Z]*$')"));
+        string memory bashCommand = string.concat(
+            'cast abi-encode "f(bytes)" $(solc --strict-assembly yul/',
+            string.concat(fileName, ".yul --bin | grep '^[0-9a-fA-Z]*$')")
+        );
 
         string[] memory inputs = new string[](3);
         inputs[0] = "bash";
@@ -21,7 +24,7 @@ contract YulDeployer is Test {
         ///@notice deploy the bytecode with the create instruction
         address deployedAddress;
         assembly {
-            deployedAddress := create(0, add(bytecode, 0x20), mload(bytecode))
+            deployedAddress := create(0, bytecode, add(bytecode, 0x20))
         }
 
         ///@notice check that the deployment was successful


### PR DESCRIPTION
The create instruction was not used correctly resulting in deployment error. 
create takes in three parameters in this order: 
1. value: value in wei to send to the new account.
2. offset: byte offset in the memory in bytes, the initialisation code for the new account.
3. size: byte size to copy (size of the initialisation code).

To fix the issue, the parameters in the create instruction were adjusted as follows:

Before:
```solidity
assembly {
            deployedAddress := create(0, add(bytecode, 0x20), mload(bytecode))
        }
```
After:
```solidity
assembly {
            deployedAddress := create(0, bytecode, add(bytecode, 0x20))
        }
```
In the "After" code snippet, the order of the offset and size parameters was swapped, ensuring the correct usage of the create instruction. Additionally, the mload(bytecode) instruction, which was returning the 32-bytes word at the location bytecode (offset in memory), was removed to ensure the correction of the problem. This should resolve the deployment error.